### PR TITLE
Pin git-secret-protector to >=1.4.0,<2 (rebuild :1 image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --update \
 RUN curl -sSL https://sdk.cloud.google.com | bash
 
 RUN pip install --no-cache-dir pipx \
-    && pipx install git-secret-protector>=1.0
+    && pipx install 'git-secret-protector>=1.4.0,<2'
 
 FROM python:3.12-alpine
 


### PR DESCRIPTION
## Why
The Dockerfile installs `git-secret-protector>=1.0` unpinned. The published `:1` image (last tag v1.1.2) therefore carries an older gsp that **cannot decrypt ciphertext produced by current gsp 1.4.0** — CI fails with `Invalid AES key` the moment a repo commits a secret encrypted by a 1.4.x CLI.

## Change
Pin to `>=1.4.0,<2`. Verified locally that gsp **1.4.0 is backward-compatible** — it decrypts files encrypted by older versions (existing org secrets keep working). Locking `<2` guards against a future breaking major.

## After merge
Cut a `v1.1.3` tag → `publish.yml` rebuilds and republishes the floating `:1` tag with gsp 1.4.x, so all consumers' CI can decrypt current-format secrets.