### PR TITLE
fix(ci): authenticate GHCR publish with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,8 +43,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: spartan-ductduong
-          password: ${{ secrets.PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push
         uses: docker/build-push-action@v4


### PR DESCRIPTION
## Problem
`publish.yml` logs into GHCR with a personal PAT (`secrets.PAT`, user `spartan-ductduong`) that is expired/invalid. The 'Login to GHCR' step fails `denied`, so the `:1` image was never rebuilt and **still ships gsp 1.2.4** (verified against the live image). Blocker behind the org-wide `Invalid AES key` CI decrypt failures.

## Fix
Use the built-in `GITHUB_TOKEN` (job already declares `packages: write`) instead of the dead PAT - GitHub's recommended GHCR publishing flow. Removes the long-lived personal-PAT dependency.

## Backward-compat verified
gsp **1.5.0** (what `>=1.4.0,<2` resolves to) decrypts a file encrypted by **1.2.4** with a versionless key blob (roundtrip via python:3.12-alpine) - safe for existing consumer secrets.

## Follow-ups (separate, not in this PR)
- App-token workflows (auto-generate-release, pull-request, update-{minor,patch}-version-tag) fail 401 - `GH_APP_PRIVATE_KEY` is stored malformed on this repo; re-store to unblock all four.
- GHCR package write-access for this repo's GITHUB_TOKEN may need granting in package settings.